### PR TITLE
✏️ TYPO - 'Volver al carrito' to 'Volver al catalogo' with empty cart button

### DIFF
--- a/src/components/Cart/Container/Container.tsx
+++ b/src/components/Cart/Container/Container.tsx
@@ -22,7 +22,7 @@ const CartContainer: React.FC<ContainerProps> = ({ items }) => {
           <Button
             variant="Add"
             onClick={() => navigate('/')}
-            text="Volver al Carrito"
+            text="Volver al Catálogo"
           ></Button>
         </div>
       )}


### PR DESCRIPTION
fix-typo(Cart): update button text from "Volver al Carrito" to "Volver al Catálogo" when cart is empty.

When the cart is empty a button is shown and it said 'Volver al carrito' instead of 'Volver al catalogo' wich is the correct text to display.